### PR TITLE
記事の表示と制限とヘッダーのログイン時と未登録時でのmenuの中身の表示の変更

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,6 +1,6 @@
 class ArticlesController < ApplicationController
   def index
-    @articles = Article.all
+    @articles = Article.order(created_at: :desc).limit(15)
   end
   
   def new

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,7 +1,7 @@
 <div class="header"> 
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
   <div class="container-fluid">
-    <a class="navbar-brand" href="#">Article-growth</a>
+    <%= link_to 'Article-growth', root_path, class: 'navbar-brand' %>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -15,11 +15,14 @@
             Menu
           </a>
           <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="#">myページ</a></li>
+          <% if user_signed_in? %> <!-- ログイン中の場合 -->
             <li><a class="dropdown-item" href="#">新規投稿</a></li>
-            <li><a class="dropdown-item" href="#">ログアウト</a></li>
-            <li><a class="dropdown-item" href="#">ログイン</a></li>
-            <li><a class="dropdown-item" href="#">新規登録</a></li>
+            <li><a class="dropdown-item" href="#">myページ</a></li>
+            <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+            <%else%> <!-- 未登録の場合 -->
+            <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>
+            <li><%= link_to 'ログイン', new_user_session_path, class: 'dropdown-item' %></li>
+            <%end%>
           </ul>
         </li>
       </ul>


### PR DESCRIPTION
# What
- ホーム画面から登録画面(新規登録か`http://localhost:3000`を入力しないとホーム画面へ行けない)への相互リンク先を記述
- 表示される記事の制限を15件にした

# Why
記事一覧機能を実装
※(次は次へのページネーションをgem導入していれる)