### PR TITLE
記事投稿機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,6 @@ gem 'rails-i18n'
 gem 'pry-rails'
 # ページネーションのためのgem
 gem 'kaminari'
+#画像加工のためのgem
+gem 'mini_magick'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,9 @@ GEM
       activesupport (>= 6.1)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -152,6 +155,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.12.0)
     mini_mime (1.1.5)
     mini_racer (0.8.0)
       libv8-node (~> 18.16.0.0)
@@ -247,6 +251,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.12.1)
+    ruby-vips (2.2.0)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -310,9 +316,11 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kaminari
+  mini_magick
   mini_racer
   mysql2 (~> 0.5)
   pg

--- a/app/assets/stylesheets/header-footer.scss
+++ b/app/assets/stylesheets/header-footer.scss
@@ -1,0 +1,3 @@
+.header {
+  border-bottom: 1px solid #ccc; // ヘッダーとボディの間に1pxの線を追加
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -5,7 +5,21 @@ class ArticlesController < ApplicationController
   end
   
   def new
+    @article = Article.new
   end
 
+  def create
+    @article = Article.new(article_params)
+    if @article.save
+      redirect_to root_path
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+ 
 
+  private
+  def article_params
+    params.require(:article).permit(:title, :content, :image).merge(user_id: current_user.id)
+  end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,17 @@
 class Article < ApplicationRecord
   belongs_to :user
+  has_one_attached :image
+  enum status: { published: 0 }
+
+  validates :title, presence: true
+  validates :content, presence: true
+
+  # 画像が添付されているかどうかを確認するカスタムバリデーション
+  validate :image_attached?, on: :create, if: -> { image.attached? }
+
+  private
+
+  def image_attached?
+    errors.add(:image, "must be attached") unless image.attached?
+  end
 end

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,0 +1,20 @@
+<%= render "layouts/header_article" %>
+<div class="container mt-4">
+  <div class="row">
+    <div class="col-md-8 offset-md-2">
+      <%= form_with(model: @article, local: true, html: { multipart: true }) do |form| %>
+        <%= form.text_field :title, class: 'form-control mb-3', placeholder: "記事のtitle" %>
+        <%= form.text_area :content, class: 'form-control mb-3', placeholder: "記事に関する内容を記述", rows: "10" %>
+
+        <% if @article.image.attached? %>
+          <%= image_tag @article.image, class: 'article-image mb-3' %>
+          <%= form.hidden_field(:image, value: @article.image.blob.filename) %>
+        <% end %>
+
+        <%= form.file_field :image, class: 'form-control mb-3', accept: 'image/*' %>
+        
+        <%= form.submit "投稿", class: 'btn btn-primary' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,7 @@
           </a>
           <ul class="dropdown-menu">
           <% if user_signed_in? %> <!-- ログイン中の場合 -->
-            <li><a class="dropdown-item" href="#">新規投稿</a></li>
+            <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
             <li><a class="dropdown-item" href="#">myページ</a></li>
             <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
             <%else%> <!-- 未登録の場合 -->

--- a/app/views/layouts/_header_article.html.erb
+++ b/app/views/layouts/_header_article.html.erb
@@ -1,0 +1,49 @@
+<div class="header"> 
+  <nav class="navbar navbar-expand-lg bg-body-tertiary">
+    <div class="container-fluid">
+      <%= link_to 'Article-growth', root_path, class: 'navbar-brand' %>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link active" aria-current="page" href="">Top</a>
+          </li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Menu
+            </a>
+            <ul class="dropdown-menu">
+              <% if user_signed_in? %> <!-- ログイン中の場合 -->
+                <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
+                <li><a class="dropdown-item" href="#">myページ</a></li>
+                <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+              <% else %> <!-- 未登録の場合 -->
+                <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>
+                <li><%= link_to 'ログイン', new_user_session_path, class: 'dropdown-item' %></li>
+              <% end %>
+            </ul>
+          </li>
+        </ul>
+        <div class="d-flex"> <!-- 右寄せのための Flex コンテナを追加 -->
+          <!-- ボタンで記事投稿と下書き記事を切り替える -->
+          <%= link_to '公開設定', new_article_path, class: 'btn btn-success me-2' %>
+          <%= link_to '下書き保存', "#", class: 'btn btn-secondary ms-2 me-2' %>
+          <!-- ユーザー名とプルダウンメニューを表示 -->
+          <% if user_signed_in? %>
+            <div class="btn-group">
+              <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <%= current_user.name %>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li><%= link_to 'myページ', "#", class: 'dropdown-item' %></li>
+                <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+              </ul>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,7 @@ module ArticleGrowth
     # config.eager_load_paths << Rails.root.join("extras")
     # 日本語の言語設定
     config.i18n.default_locale = :ja
+
+    config.active_storage.variant_processor = :mini_magick
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'articles#index'
-  resources :articles, only: :index
+  resources :articles, only: [:index, :new, :create]
 end

--- a/db/migrate/20231121122434_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20231121122434_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_13_134122) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_21_122434) do
+  create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", charset: "utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", charset: "utf8", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "articles", charset: "utf8", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
@@ -34,5 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_13_134122) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
 end


### PR DESCRIPTION
# What
- newアクションとcreateアクションを実装
- ルーティングを作成
-  viewをBootStrapを使用して作成
- imageをnewアクションで挿入できるようにGemを追加
- headerを記事投稿時と一覧時で表示が変更するようにviewファイルを追加

# Why
記事投稿機能実装
(次回は記事のモデルテスト行う予定)