### PR TITLE
下書き記事機能を作成

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,25 +1,39 @@
 class ArticlesController < ApplicationController
+  before_action :authenticate_user!, only: [:new, :create]
   def index
-    @articles = Article.order(updated_at: :desc).page(params[:page]).per(15)
-
+    @articles = Article.published.order(updated_at: :desc).page(params[:page]).per(10)
   end
-  
+
+  def drafts
+    @drafts = Article.where(status: 'draft').order(created_at: :desc).page(params[:page]).per(10)
+  end
+
   def new
     @article = Article.new
   end
 
   def create
     @article = Article.new(article_params)
+    if params[:draft] == 'true'
+      @article.status = 'draft'
+    elsif params[:published] == '投稿'
+      @article.status = 'published'
+    end
+
     if @article.save
-      redirect_to root_path
+      if @article.status == 'draft'
+        redirect_to drafts_path, notice: '記事が下書き保存されました。'
+      else
+        redirect_to root_path, notice: '記事が公開されました。'
+      end
     else
-      render :new, status: :unprocessable_entity
+      render :new
     end
   end
- 
 
   private
+
   def article_params
-    params.require(:article).permit(:title, :content, :image).merge(user_id: current_user.id)
+    params.require(:article).permit(:title, :content, :image, :status).merge(user_id: current_user.id)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ApplicationRecord
   belongs_to :user
   has_one_attached :image
-  enum status: { published: 0 }
+  enum status: { published: 0, draft: 1 }
 
   validates :title, presence: true
   validates :content, presence: true
@@ -12,6 +12,6 @@ class Article < ApplicationRecord
   private
 
   def image_attached?
-    errors.add(:image, "must be attached") unless image.attached?
+    errors.add(:image, 'must be attached') unless image.attached?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,7 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :articles 
+  has_many :articles
 
   validates :name, presence: true, length: { minimum: 2 }
-  
 end

--- a/app/views/articles/_post.html.erb
+++ b/app/views/articles/_post.html.erb
@@ -1,9 +1,0 @@
-<div class="main">
-  <div class="inner">
-    <div class="post__wrapper">
-      <h2 class="page-heading">新規投稿</h2>
-        <%= render partial: 'post', locals: {article: @article} %>
-        <%# 部分テンプレートでフォームを表示する %>
-    </div>
-  </div>
-</div>

--- a/app/views/articles/drafts.html.erb
+++ b/app/views/articles/drafts.html.erb
@@ -1,0 +1,17 @@
+<%= render "layouts/header_article" %>
+<div class="article-info">
+<% @drafts.each do |article| %> 
+  <div class="article-box">
+    <p class="article-name">
+      <%= article.user.name %>
+    </p>
+    <p class="article-title">
+      <%= article.title %>
+    </p> 
+    <p class="update-time">
+      <%= article.updated_at.strftime('%Y-%m-%d') %>
+    </p>
+  </div>
+<% end %>
+<%= paginate @drafts %>
+</div>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -13,7 +13,8 @@
 
         <%= form.file_field :image, class: 'form-control mb-3', accept: 'image/*' %>
         
-        <%= form.submit "投稿", class: 'btn btn-primary' %>
+        <%= form.submit "投稿", class: 'btn btn-primary',name: "published", value: "投稿" %>
+        <%= form.button "下書き保存", class: "btn btn-secondary", name: "draft", value: "true" %>
       <% end %>
     </div>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,8 +17,7 @@
           <ul class="dropdown-menu">
           <% if user_signed_in? %> <!-- ログイン中の場合 -->
             <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
-            <li><a class="dropdown-item" href="#">myページ</a></li>
-            <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+            <li><%= link_to '下書き一覧', drafts_articles_path, class: 'dropdown-item' %></li>
             <%else%> <!-- 未登録の場合 -->
             <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>
             <li><%= link_to 'ログイン', new_user_session_path, class: 'dropdown-item' %></li>
@@ -26,10 +25,25 @@
           </ul>
         </li>
       </ul>
-      <form class="d-flex" role="search">
-        <input class="form-control me-2" type="search" placeholder="Search" aria-label="Search">
-        <button class="btn btn-outline-success" type="submit">Search</button>
-      </form>
+<div class="d-flex justify-content-end align-items-center">
+  <form class="me-2" role="search">
+    <div class="d-flex">
+      <input class="form-control" type="search" placeholder="Search" aria-label="Search">
+      <button class="btn btn-outline-success" type="submit">Search</button>
+    </div>
+  </form>
+
+  <% if user_signed_in? %>
+    <div class="btn-group">
+      <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <%= current_user.name %>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end">
+        <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+      </ul>
+    </div>
+  <% end %>
+</div>
     </div>
   </div>
 </nav>

--- a/app/views/layouts/_header_article.html.erb
+++ b/app/views/layouts/_header_article.html.erb
@@ -16,9 +16,12 @@
             </a>
             <ul class="dropdown-menu">
               <% if user_signed_in? %> <!-- ログイン中の場合 -->
-                <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
-                <li><a class="dropdown-item" href="#">myページ</a></li>
-                <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
+                  <% unless controller_name == 'articles' && action_name == 'new' %> <!-- ArticlesControllerのnewアクションにいない場合 -->
+                    <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
+                  <% end %>
+                <% unless current_page?(drafts_articles_path) %> <!-- drafts_articles_path ページの場合は非表示 -->
+                <li><%= link_to '下書き一覧', drafts_articles_path, class: 'dropdown-item' %></li>
+                <% end %>
               <% else %> <!-- 未登録の場合 -->
                 <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>
                 <li><%= link_to 'ログイン', new_user_session_path, class: 'dropdown-item' %></li>
@@ -27,9 +30,6 @@
           </li>
         </ul>
         <div class="d-flex"> <!-- 右寄せのための Flex コンテナを追加 -->
-          <!-- ボタンで記事投稿と下書き記事を切り替える -->
-          <%= link_to '公開設定', new_article_path, class: 'btn btn-success me-2' %>
-          <%= link_to '下書き保存', "#", class: 'btn btn-secondary ms-2 me-2' %>
           <!-- ユーザー名とプルダウンメニューを表示 -->
           <% if user_signed_in? %>
             <div class="btn-group">
@@ -37,7 +37,6 @@
                 <%= current_user.name %>
               </button>
               <ul class="dropdown-menu dropdown-menu-end">
-                <li><%= link_to 'myページ', "#", class: 'dropdown-item' %></li>
                 <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
               </ul>
             </div>

--- a/app/views/layouts/_header_login.html.erb
+++ b/app/views/layouts/_header_login.html.erb
@@ -8,7 +8,7 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item">
-          <a class="nav-link active" aria-current="page" href="">Top</a>
+          <%= link_to 'Top', root_path, class: 'nav-link active', aria: { current: 'page' } %>
         </li>
       </ul>
     </div>

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 15
+  config.default_per_page = 10
   config.max_per_page = nil
   config.window = 4
   # config.outer_window = 6

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'articles#index'
   resources :articles, only: [:index, :new, :create]
+  get '/articles/drafts', to: 'articles#drafts', as: 'drafts_articles'
 end

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.sentence }
     content { Faker::Lorem.paragraph }
-        # 画像のファイルパスを指定してアタッチ
-        image do
-          Rack::Test::UploadedFile.new(
-            Rails.root.join('app', 'assets', 'images', 'niji.jpeg')# 画像ファイルのパスを指定
-          )
-        end
+    # 画像のファイルパスを指定してアタッチ
+    image do
+      Rack::Test::UploadedFile.new(
+        Rails.root.join('app', 'assets', 'images', 'niji.jpeg') # 画像ファイルのパスを指定
+      )
+    end
     association :user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -16,19 +16,19 @@ RSpec.describe Article, type: :model do
     end
     context '記事が投稿できない場合' do
       it 'titleがない場合記事が投稿できない' do
-        @article.title = ""
+        @article.title = ''
         @article.valid?
-        expect(@article.errors.full_messages).to include "Titleを入力してください"
+        expect(@article.errors.full_messages).to include 'Titleを入力してください'
       end
       it 'contentがない場合記事が投稿できない' do
-        @article.content = ""
+        @article.content = ''
         @article.valid?
-        expect(@article.errors.full_messages).to include "Contentを入力してください"
+        expect(@article.errors.full_messages).to include 'Contentを入力してください'
       end
       it 'userが紐づいていない場合記事が投稿できない' do
         @article.user = nil
         @article.valid?
-        expect(@article.errors.full_messages).to include "Userを入力してください"
+        expect(@article.errors.full_messages).to include 'Userを入力してください'
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
# What
- draftsのviewsを作成
- enumを使用して記事投稿時に0と1で公開と下書き保存でモデルをvalidateを行いました。
- ルーティングにdraftsのviewに対するルーティングとdraftsメソッドを行うような記述を作成
- ページ遷移後にプルダウンメニューを表示するとしないの条件分岐を行いました

# Why
下書き記事機能作成のため