### PR TITLE
記事削除機能

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,8 +3,8 @@ class Article < ApplicationRecord
   has_one_attached :image
   enum status: { published: 0, draft: 1 }
 
-  validates :title, presence: true
-  validates :content, presence: true
+  validates :title, presence: { message: 'はタイトルを入力してください' }
+  validates :content, presence: { message: 'は内容を入力してください' }
 
   # 画像が添付されているかどうかを確認するカスタムバリデーション
   validate :image_attached?, on: :create, if: -> { image.attached? }

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -3,6 +3,7 @@
   <div class="row">
     <div class="col-md-8 offset-md-2">
       <%= form_with(model: @article, local: true, html: { multipart: true }) do |form| %>
+        <%= render 'layouts/error_messages', model: form.object %>
         <%= form.text_field :title, class: 'form-control mb-3', placeholder: "記事のtitle" %>
         <%= form.text_area :content, class: 'form-control mb-3', placeholder: "記事に関する内容を記述", rows: "10" %>
 

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,8 +1,9 @@
-<%= render "layouts/header_article" %>
+<%= render "layouts/header" %>
 <div class="container mt-4">
   <div class="row">
     <div class="col-md-8 offset-md-2">
       <%= form_with(model: @article, local: true, html: { multipart: true }) do |form| %>
+      <%= render 'layouts/error_messages', model: form.object %>
         <%= form.text_field :title, class: 'form-control mb-3', placeholder: "記事のtitle" %>
         <%= form.text_area :content, class: 'form-control mb-3', placeholder: "記事に関する内容を記述", rows: "10" %>
 

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -16,7 +16,9 @@
           </a>
           <ul class="dropdown-menu">
           <% if user_signed_in? %> <!-- ログイン中の場合 -->
+            <% unless controller_name == 'articles' && action_name == 'new' %> <!-- ArticlesControllerのnewアクションにいない場合 -->
             <li><%= link_to '新規投稿', new_article_path, class: 'dropdown-item' %></li>
+            <% end %>
             <li><%= link_to '下書き一覧', drafts_articles_path, class: 'dropdown-item' %></li>
             <%else%> <!-- 未登録の場合 -->
             <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>

--- a/app/views/layouts/_header_article.html.erb
+++ b/app/views/layouts/_header_article.html.erb
@@ -24,6 +24,7 @@
                 <% end %>
                   <% if (@article && current_user == @article.user) %> <!-- 記事が存在し、かつログインユーザーが投稿者の場合 -->
                     <li><%= link_to '記事編集', edit_article_path(@article), class: 'dropdown-item' %></li>
+                    <li><%= link_to '記事削除', article_path(@article), data: { turbo_method: :delete }, class: 'dropdown-item' %></li>
                   <% end %>
               <% else %> <!-- 未登録の場合 -->
                 <li><%= link_to '新規登録', new_user_registration_path, class: 'dropdown-item' %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'articles#index'
-  resources :articles, only: [:index, :show, :new, :create, :edit, :update]
+  resources :articles
   get '/articles/drafts', to: 'articles#drafts', as: 'drafts_articles'
 end


### PR DESCRIPTION
# What
- destroyメソッドを作成し、下書き記事と通常の記事で場合わけして削除後の遷移ページへの記述を追加
- 削除ボタンを下書き記事の場合は記事編集画面の時に、通常時では詳細記事の時の投稿者のみの場合削除ボタンをmenuに追加
- 削除ボタンが投稿者しかできないような記述を追加
- 何回もcontrollerで使用しているものはprivateメソッドに記述してbefore_actionに行うアクションを記述

# Why
記事削除機能とリファクタリング実装