### PR TITLE
N+1問題の解消するための記述

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -2,11 +2,11 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :destroy]
   before_action :show_article, only: [:edit, :update, :destroy]
   def index
-    @articles = Article.published.order(updated_at: :desc).page(params[:page]).per(10)
+    @articles = Article.published.includes(:user).order(updated_at: :desc).page(params[:page]).per(10)
   end
 
   def drafts
-    @drafts = Article.where(status: 'draft').order(created_at: :desc).page(params[:page]).per(10)
+    @drafts = Article.where(status: 'draft').includes(:user).order(created_at: :desc).page(params[:page]).per(10)
   end
 
   def show


### PR DESCRIPTION
# What
-  記事の一覧のデータベースにクエリする際、記事の量が増えるとその情報取得のためのユーザー情報を一緒に読み込むための JOIN 操作を含んだ eager loading（事前読み込み）を行いN+1問題を回避し、パフォーマンスを向上させるため記述

# Why
N+1問題の回避のための一覧表示のインスタンス変数にincludes(:user)を追加で記述
