### PR TITLE
コメント機能を実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import "users";
 @import "header-footer";
 @import "articles";
+@import "comments"

--- a/app/assets/stylesheets/comments.scss
+++ b/app/assets/stylesheets/comments.scss
@@ -1,0 +1,45 @@
+.comments-cont {
+  background-color: #fff; /* 背景色を白に設定 */
+  padding-top: 10px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  display: block;
+  width: 55%;
+  margin: 0 auto; /* 中央に寄せる */
+}
+
+.comments-cont #comments {
+
+  h4 {
+    font-size: 1.5em;
+    color: #333;
+
+  }
+
+  .comment {
+    border-top: 1px solid #ddd;
+    padding: 10px;
+    margin-top: 10px;
+    font-size: 16px;
+    color: #555;
+
+    .user-info {
+      font-weight: bold;
+    }
+  }
+}
+
+.comment-form1 {
+  padding-top: 20px;
+  margin-bottom: 30px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: #f4f4f4; /* 背景色を白に設定 */
+  width: 45%;
+  margin: 0 auto;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}

--- a/app/channels/comment_channel.rb
+++ b/app/channels/comment_channel.rb
@@ -1,0 +1,10 @@
+class CommentChannel < ApplicationCable::Channel
+  def subscribed
+    @article = Article.find(params[:article_id]) # 追記
+    stream_for @article # 追記
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -16,6 +16,8 @@ class ArticlesController < ApplicationController
       show_drafts
     else
       show_article
+      @comments = @article.comments.includes(:user)
+      @comment = Comment.new
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,15 @@
+class CommentsController < ApplicationController
+  def create
+    @comment = Comment.new(comment_params)
+    @article = Article.find(params[:article_id])
+    return unless @comment.save
+
+    CommentChannel.broadcast_to @article, { comment: @comment, user: @comment.user } # 追加
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:text).merge(user_id: current_user.id, article_id: params[:article_id])
+  end
+end

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,2 @@
+module CommentsHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,3 +5,4 @@
 //= require bootstrap-sprockets
 import "@hotwired/turbo-rails"
 import "controllers"
+import "channels"

--- a/app/javascript/channels/comment_channel.js
+++ b/app/javascript/channels/comment_channel.js
@@ -1,0 +1,31 @@
+import consumer from "channels/consumer"
+
+if(location.pathname.match(/\/articles\/\d/)){
+
+
+  consumer.subscriptions.create({
+    channel: "CommentChannel",
+    article_id: location.pathname.match(/\d+/)[0]
+  }, {
+
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    const html = `
+    <div class="comment">
+      <p class="user-info">${data.user.name}： </p>
+      <p>${data.comment.text}</p>
+    </div>`
+    const comments = document.getElementById("comments")
+    comments.insertAdjacentHTML('beforeend', html)
+    const commentForm = document.getElementById("comment-form")
+    commentForm.querySelector(".comment-text").value = "";
+  }
+})
+}

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,2 @@
+// Import all the channels to be used by Action Cable
+import "channels/comment_channel"

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ApplicationRecord
   belongs_to :user
+  has_many :comments
   has_one_attached :image
   enum status: { published: 0, draft: 1 }
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,4 @@
+class Comment < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :articles
+  has_many :comments
 
   validates :name, presence: true, length: { minimum: 2 }
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,7 +5,7 @@
     <h1><%= @article.title %></h1>
     <p>投稿日: <%= @article.created_at.strftime('%Y-%m-%d') %>  , 最終更新日: <%= @article.updated_at.strftime('%Y-%m-%d') %></p>
     <div class="article-content">
-      <%=@article.content %> <!-- raw メソッドを使って HTML タグをそのまま表示 -->
+      <%=@article.content %> 
     </div>
     <div class="article_image">
     <% if @article && @article.image.attached? %>
@@ -14,4 +14,28 @@
     </div>
   </div>
 </div>
+<%# コメント表示 %>
+<div class="comments-cont">
+  <div id="comments">
+    <h4>＜コメント一覧＞</h4>
+      <% @article.comments.each do |comment| %>
+        <div class="comment">
+          <p class="user-info"><%= comment.user.name %>： </p>
+          <p><%= comment.text%></p>
+        </div>
+      <% end %>
+  </div>
 
+<%# コメントフォーム欄 %>
+<div class="comment-form1">
+  <% if user_signed_in? %>
+    <%= form_with model: [@article, @comment], id: "comment-form" do |f| %>
+      <%= f.text_area :text , class: "comment-text"%>
+      <%= f.submit "コメントをする", class: "comment-submit1" %>
+    <% end %>
+  <% end %>
+</div>
+</div>
+<div class="footer-protect">
+ <%= render "layouts/footer" %>
+</div>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,6 @@ test:
   adapter: test
 
 production:
-  adapter: redis
+  adapter: async
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: article_growth_production

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,5 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.2.3/dist/js/bootstrap.esm.js"
 pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.6/lib/index.js"
+pin "@rails/actioncable", to: "actioncable.esm.js"
+pin_all_from "app/javascript/channels", under: "channels"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     collection do
       get 'search'
     end
+    resources :comments, only: :create
   end
   get '/articles/drafts', to: 'articles#drafts', as: 'drafts_articles'
 end

--- a/db/migrate/20231128134924_create_comments.rb
+++ b/db/migrate/20231128134924_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :comments do |t|
+      t.text :text
+      t.integer :user_id
+      t.integer :article_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_21_122434) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_28_134924) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -47,6 +47,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_122434) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "comments", charset: "utf8", force: :cascade do |t|
+    t.text "text"
+    t.integer "user_id"
+    t.integer "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|

--- a/test/channels/comment_channel_test.rb
+++ b/test/channels/comment_channel_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class CommentChannelTest < ActionCable::Channel::TestCase
+  # test "subscribes" do
+  #   subscribe
+  #   assert subscription.confirmed?
+  # end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  article_id: 1
+
+two:
+  user_id: 1
+  article_id: 1

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CommentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
- コメント機能実装のためコメントのモデルとコメントのコントローラーを作成
- コメント機能のcreateアクションのみをarticleの記事に紐づくコメントの作成機能の実装
- コメントのフォーム欄と一覧のviewを記事のviewに表示するようなviewを作成
- JavaScriptで情報を受け取るような設定を追加
- Renderでも実装できるようにconfigのcable.ymlの設定を修正


# Why
コメント機能実装のため