### PR TITLE
いいね機能の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,8 @@ Style/FrozenStringLiteralComment:
 # メソッドパラメータ名の最小文字数を設定
 Naming/MethodParameterName:
  MinNameLength: 1
+
+ Include:
+  - 'app/controllers/likes_controller.rb':
+      Style/SymbolProc:
+        Enabled: false

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,4 +4,4 @@
 @import "users";
 @import "header-footer";
 @import "articles";
-@import "comments"
+@import "comments";

--- a/app/assets/stylesheets/articles.scss
+++ b/app/assets/stylesheets/articles.scss
@@ -28,7 +28,6 @@ $article-background: #fff; // 記事ボックスの背景色
   border: 1px solid $primary-color;
   border-radius: 5px;
   display: flex;
-  flex-direction: column;
   justify-content: space-between;
 
   a {
@@ -95,6 +94,23 @@ $article-background: #fff; // 記事ボックスの背景色
   }
 }
 
+
+.article_likes {
+  .btn.btn-outline-danger {
+    color: white; 
+  }
+
+  .bi-heart-fill {
+    // ここにハートのアイコンに適用するカスタムスタイルを追加
+    color: red; // ハートを赤色にする例
+    font-size: 1em; // フォントサイズを調整する例
+  }
+  .bi-heart {
+    color: red; // ハートを赤色にする例
+    font-size: 1em; // フォントサイズを調整する例
+
+  }
+}
 
 
 

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,25 @@
+class LikesController < ApplicationController
+  before_action :set_tweet
+  def create
+    if current_user && current_user != @article.user
+      like = current_user.likes.build(article_id: params[:article_id])
+      like.save
+      respond_to do |format|
+        format.js
+      end
+    end
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    like = Like.find_by(article_id: params[:article_id], user_id: current_user.id)
+    like.destroy
+    respond_to do |format|
+      format.js
+    end
+  end
+
+  def set_tweet
+    @article = Article.find(params[:article_id])
+  end
+end

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,7 @@
 class Article < ApplicationRecord
   belongs_to :user
   has_many :comments
+  has_many :likes
   has_one_attached :image
   enum status: { published: 0, draft: 1 }
 
@@ -12,6 +13,10 @@ class Article < ApplicationRecord
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[title content]
+  end
+
+  def liked_by?(user)
+    likes.where(user_id: user.id).exists?
   end
 
   private

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :article
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :articles
+  has_many :likes
   has_many :comments
 
   validates :name, presence: true, length: { minimum: 2 }

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -4,6 +4,7 @@
   <% @articles.each do |article| %> 
     <div class="article-box">
      <%= link_to article_path(article) do %>
+      <div class ="article-box-info">
       <p class="article-name">
         <%= article.user.name %>
       </p>
@@ -13,6 +14,10 @@
       <p class="update-time">
         <%= article.updated_at.strftime('%Y-%m-%d') %>
       </p>
+      </div>
+      <div id="like-btn<%= article.id %>">
+      <%= render partial: "likes/like", locals: { article: article } %>
+      </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -4,6 +4,9 @@
     <p>投稿者: <%= @article.user.name %></p>
     <h1><%= @article.title %></h1>
     <p>投稿日: <%= @article.created_at.strftime('%Y-%m-%d') %>  , 最終更新日: <%= @article.updated_at.strftime('%Y-%m-%d') %></p>
+    <div id="like-btn<%= @article.id %>">
+      <%= render partial: "likes/like", locals: { article: @article } %>
+    </div>
     <div class="article-content">
       <%=@article.content %> 
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.min.css" integrity="sha384-fFxL8wXRpg9gVqGpY+URMtLr3fLL0WBbo4NBQ+IWwMDYjIjI5VQ46XlJm5+BUlXJ" crossorigin="anonymous">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/likes/ create.js.erb
+++ b/app/views/likes/ create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('like-btn<%= @article.id %>').innerHTML = "<%= j(render partial: 'likes/like', locals: {article: @article}) %>"

--- a/app/views/likes/_like.html.erb
+++ b/app/views/likes/_like.html.erb
@@ -1,0 +1,11 @@
+
+  <% if user_signed_in? && article.liked_by?(current_user)%>
+    <%=link_to article_likes_path(article.id),  data: { turbo_method: :delete }, class: "article_likes btn btn-outline-danger", remote: true do %>
+      <i class="bi bi-heart-fill"></i>
+    <% end %>
+  <% else %>
+    <%=link_to article_likes_path(article.id), data: { turbo_method: :post }, class: "article_likes btn btn-outline-danger", remote: true do %>
+    <i class="bi bi-heart"></i>
+    <% end %>
+  <% end %>
+<p>いいね <%=article.likes.count %></p>

--- a/app/views/likes/destroy.js.erb
+++ b/app/views/likes/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('like-btn<%= @article.id %>').innerHTML = "<%= j(render partial: 'likes/like', locals: {article: @article}) %>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'articles#index'
   resources :articles do
+    resource :likes, only: [:create, :destroy]
     collection do
       get 'search'
     end

--- a/db/migrate/20231203012650_create_likes.rb
+++ b/db/migrate/20231203012650_create_likes.rb
@@ -1,0 +1,10 @@
+class CreateLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, foreign_key: true
+      t.references :article, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_28_134924) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_03_012650) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,6 +57,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_134924) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "favorites", charset: "utf8", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "likes", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "article_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["article_id"], name: "index_likes_on_article_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "users", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", default: "", null: false
@@ -73,4 +89,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_28_134924) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "articles", "users"
+  add_foreign_key "likes", "articles"
+  add_foreign_key "likes", "users"
 end

--- a/test/controllers/likes_controller_test.rb
+++ b/test/controllers/likes_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LikesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/likes.yml
+++ b/test/fixtures/likes.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/like_test.rb
+++ b/test/models/like_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LikeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
- likeモデルを作成し記事に対していいねをつけるためのカラムを記述
- userとarticleとlikeのモデルのアソシエーションを記述
- likes_controllerを作成しいいねのアクションを作るためcreateとdestroyアクションを作成
- ユーザーが該当記事にいいね済かどうかを判定する必要があるためarticleのモデルに記述
- viewを部分テンプレート作成とbootstrapのiconを導入しハートのアイコンに変更
- ログインユーザー(記事の投稿者ではない人)のみがいいねできてそれ以外の人が押すとそのページに遷移するような記述を追加

# Why
いいね機能の実装