### PR TITLE
tab機能追加

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -100,9 +100,12 @@ class ArticlesController < ApplicationController
 
   def show_drafts
     if user_signed_in?
-      @drafts = Article.where(status: 'draft',
-                              user: current_user).includes(:user).order(updated_at: :desc).page(params[:page]).per(10)
-      render 'draft'
+      @drafts = Article.where(status: 'draft', user: current_user)
+                       .includes(:user)
+                       .order(updated_at: :desc)
+                       .page(params[:page])
+                       .per(10)
+      render 'draft' if @drafts.present? # 投稿が存在する場合のみ表示
     else
       redirect_to root_path, status: :unprocessable_entity
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,18 @@ class UsersController < ApplicationController
   end
 
   def show
+    likes = Like.where(user_id: @user.id).pluck(:article_id)
+    @like_articles = Article.where(id: likes)
+                            .limit(10)  # 10件までに制限
+                            .page(params[:page])
+                            .per(10)
+
+    @drafts = Article.where(status: 'draft', user: current_user)
+                      .includes(:user)
+                      .order(updated_at: :desc)
+                      .limit(5)  # 5件までに制限
+                      .page(params[:page])
+                      .per(5)
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,6 +18,7 @@ class Article < ApplicationRecord
   def liked_by?(user)
     likes.pluck(:user_id).include?(user.id)
   end
+
   private
 
   def image_attached?

--- a/app/views/articles/draft.html.erb
+++ b/app/views/articles/draft.html.erb
@@ -1,7 +1,8 @@
 <%= render "layouts/header_article" %>
 <div class="article-info">
 <h1 class="centered-text">下書き記事一覧</h1>
-<% @drafts.each do |article| %> 
+<% @drafts.each do |article| %>
+<% if article.user == current_user %> <!-- 投稿者がログインユーザーの記事のみ表示 --> 
   <%= link_to edit_article_path(article), class: 'article-link' do %>
   <div class="article-box">
     <p class="article-name">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,9 +13,68 @@
           </tr>
         </table>
       </div>
-      <%= link_to 'いいねした記事一覧ページ', likes_user_path(@user), class: "btn btn-info mb-4" %>
-      <%= link_to '記事一覧ページ', root_path, class: "btn btn-info mb-4" %>
     </div>
-    <div class="col-md-2"></div>  
   </div>
+</div>
+
+<ul class="nav nav-tabs" id="myTab" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="home-tab" data-bs-toggle="tab" data-bs-target="#home-tab-pane" type="button" role="tab" aria-controls="home-tab-pane" aria-selected="true">いいね記事一覧</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="profile-tab" data-bs-toggle="tab" data-bs-target="#profile-tab-pane" type="button" role="tab" aria-controls="profile-tab-pane" aria-selected="false">下書き記事一覧</button>
+  </li>
+
+</ul>
+<div class="tab-content" id="myTabContent">
+  <div class="tab-pane fade show active" id="home-tab-pane" role="tabpanel" aria-labelledby="home-tab" tabindex="0">
+  <div class="article-info">
+<h1 class="centered-text">いいねした投稿一覧</h1>
+  <% @like_articles.each do |article| %> 
+    <div class="article-box">
+      <%= link_to article_path(article) do %>
+      <div class ="article-box-info">
+      <p class="article-name">
+        <%= article.user.name %>
+      </p>
+      <p class="article-title">
+        <%= article.title %>
+      </p> 
+      <p class="update-time">
+        <%= article.updated_at.strftime('%Y-%m-%d') %>
+      </p>
+      </div>
+      <div id="like-btn<%= article.id %>">
+      <%= render partial: "likes/like", locals: { article: article } %>
+      </div>
+      <% end %>
+    </div>
+  <% end %>
+  <%= paginate @like_articles %>
+  </div>
+  </div>
+
+
+
+  <div class="tab-pane fade" id="profile-tab-pane" role="tabpanel" aria-labelledby="profile-tab" tabindex="0">
+  <div class="article-info">
+<h1 class="centered-text">下書き記事一覧</h1>
+<% @drafts.each do |article| %> 
+  <%= link_to edit_article_path(article), class: 'article-link' do %>
+  <div class="article-box">
+    <p class="article-name">
+      <%= article.user.name %>
+    </p>
+    <p class="article-title">
+      <%= article.title %>
+    </p> 
+    <p class="update-time">
+      <%= article.updated_at.strftime('%Y-%m-%d') %>
+    </p>
+      <% end %>
+  </div>
+<% end %>
+</div>
+</div>
+<%= render "layouts/footer" %> 
 </div>


### PR DESCRIPTION
# What
- tab機能を実装してマイページでいいね一覧と下書き記事一覧をページ遷移せずに切り替えを行うよう記述
- ページでの表示は制限を設けていいねは10件下書き記事は5件の表示

# Why
tab機能をBootstrapで実装